### PR TITLE
Bootstrap peers

### DIFF
--- a/src/ipfs/get-ipfs.js
+++ b/src/ipfs/get-ipfs.js
@@ -1,6 +1,28 @@
 let ipfsInstance;
 const DEFAULT_PERMISSIONS = ["id", "version", "add", "cat", "dag"];
 
+const addBootstrapPeers = async (ipfs, peers) => {
+  if (peers && peers.length > 0) {
+    const isOnline = await ipfs.isOnline();
+    if (isOnline) {
+      await ipfs.stop();
+    }
+    await Promise.all(peers.map(p => ipfs.bootstrap.add(p)));
+    await ipfs.start();
+  }
+  return ipfs;
+};
+
+const normalizePermissions = (permissions = DEFAULT_PERMISSIONS) => {
+  if (permissions.indexOf("id") < 0) {
+    permissions.push("id");
+  }
+  if (permissions.indexOf("version") < 0) {
+    permissions.push("version");
+  }
+  return permissions;
+};
+
 export const ipfsIsWorking = async ipfs => {
   try {
     const id = await ipfs.id();
@@ -14,23 +36,18 @@ export const ipfsIsWorking = async ipfs => {
   }
 };
 
-export const loadWindowIpfs = async permissions => {
+export const loadWindowIpfs = async config => {
   if (window.ipfs) {
     let ipfs = window.ipfs;
     if (window.ipfs.enable) {
-      // if user set permissions, make sure id and version are both added
-      if (permissions.indexOf("id") < 0) {
-        permissions.push("id");
-      }
-      if (permissions.indexOf("version") < 0) {
-        permissions.push("version");
-      }
+      const permissions = normalizePermissions(config.permissions);
       ipfs = await window.ipfs.enable({
         commands: permissions
       });
     }
     const isWorking = await ipfsIsWorking(ipfs);
     if (isWorking) {
+      await addBootstrapPeers(ipfs, config.bootstrap);
       return ipfs;
     } else {
       return null;
@@ -39,12 +56,14 @@ export const loadWindowIpfs = async permissions => {
   return null;
 };
 
-export const loadJsIpfs = async () => {
+export const loadJsIpfs = async config => {
   return new Promise((resolve, reject) => {
     const script = document.createElement("script");
     script.src = "https://unpkg.com/ipfs/dist/index.min.js";
     script.onload = async () => {
-      const ipfs = await window.Ipfs.create();
+      console.log(window.Ipfs);
+      const ipfs = await window.Ipfs.create({ start: false });
+      await addBootstrapPeers(ipfs, config.bootstrap);
       const isWorking = await ipfsIsWorking(ipfs);
       if (isWorking) {
         resolve(ipfs);
@@ -57,20 +76,20 @@ export const loadJsIpfs = async () => {
   });
 };
 
-const getIpfs = async (permissions = DEFAULT_PERMISSIONS) => {
+const getIpfs = async (config = {}) => {
   // if already instantiated
   if (ipfsInstance) {
     return ipfsInstance;
   }
 
-  ipfsInstance = await loadWindowIpfs(permissions);
+  ipfsInstance = await loadWindowIpfs(config);
   if (ipfsInstance) {
     console.log("window.ipfs is available!");
-    return ipfsInstance;
+  } else {
+    console.log("window.ipfs is not available, downloading from CDN...");
+    ipfsInstance = await loadJsIpfs(config);
   }
 
-  console.log("window.ipfs is not available, downloading from CDN...");
-  ipfsInstance = await loadJsIpfs();
   return ipfsInstance;
 };
 

--- a/src/ipfs/get-ipfs.js
+++ b/src/ipfs/get-ipfs.js
@@ -61,7 +61,6 @@ export const loadJsIpfs = async config => {
     const script = document.createElement("script");
     script.src = "https://unpkg.com/ipfs/dist/index.min.js";
     script.onload = async () => {
-      console.log(window.Ipfs);
       const ipfs = await window.Ipfs.create({ start: false });
       await addBootstrapPeers(ipfs, config.bootstrap);
       const isWorking = await ipfsIsWorking(ipfs);

--- a/src/ipfs/preferences.js
+++ b/src/ipfs/preferences.js
@@ -1,6 +1,14 @@
-import getIpfs from "../ipfs/getIpfs";
+import getIpfsWithConfig from "../ipfs/get-ipfs";
 
 export const DefaultCid = "QmUMQ5Zxu94gwGq96hGEBc2hzoMkywUctbySw7YY6g8ktw";
+
+const getIpfs = async () => {
+  return await getIpfsWithConfig({
+    bootstrap: [
+      "/ip4/127.0.0.1/tcp/4002/ws/ipfs/QmY4N8hPzGQUPDJc8tMWuQokJswStUZk9SkBACCHoVZpCS"
+    ]
+  });
+};
 
 export const validPreferences = preferences => {
   return (


### PR DESCRIPTION
# Problem
Need to add bootstrap peers to ipfs node

# Solution
- Add bootstrap peers before node startup
- In the case of `window.ipfs`, stop node, add peers, and then restart