### PR TITLE
upgraded eslint-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@material-ui/core": "^4.3.2",
     "@material-ui/icons": "^4.2.1",
     "classnames": "^2.2.6",
+    "eslint-utils": "1.4.1",
     "get-ipfs": "^0.0.3",
     "prop-types": "^15.7.2",
     "react": "^16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3760,6 +3760,13 @@ eslint-scope@^5.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-utils@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.1.tgz#73f99ce55beebe4d956bfe51cb087bab2399fd9e"
+  integrity sha512-mRQKp/gEImJj7aP2be4F0cIQMxlgY9em9RFtxDmkwqV3cUKCK/mvso36wGQFJCNnrBKrEMBZkOLDrMSM+BpG3A==
+  dependencies:
+    eslint-visitor-keys "^1.0.0"
+
 eslint-utils@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.0.tgz#e2c3c8dba768425f897cf0f9e51fe2e241485d4c"


### PR DESCRIPTION
# Problem
`eslint-utils@1.3.1` has a security vulnerability

# Solution
upgrade to patched version `1.4.1`