### PR TITLE
make env variables optional with elegant fallbacks

### DIFF
--- a/src/ipfs/preferences.js
+++ b/src/ipfs/preferences.js
@@ -1,20 +1,21 @@
 import getIpfsWithConfig from "get-ipfs";
-import { FissionUser } from "@fission-suite/client";
+import { pin } from "@fission-suite/client";
 
 const ipfsProvider =
   process.env.REACT_APP_INTERPLANETARY_FISSION_URL || "https://hostless.dev";
 const username = process.env.REACT_APP_INTERPLANETARY_FISSION_USERNAME;
 const password = process.env.REACT_APP_INTERPLANETARY_FISSION_PASSWORD;
 const bootstrapNode = process.env.REACT_APP_BOOTSTRAP_NODE;
-const fission = new FissionUser(username, password, ipfsProvider);
 
 export const DefaultCid = "QmUMQ5Zxu94gwGq96hGEBc2hzoMkywUctbySw7YY6g8ktw";
 
 const getIpfs = async () => {
+  if (bootstrapNode) {
+    return getIpfsWithConfig({
+      bootstrap: [bootstrapNode]
+    });
+  }
   return getIpfsWithConfig();
-  const ipfs = await getIpfsWithConfig({
-    bootstrap: [bootstrapNode]
-  });
 };
 
 export const validPreferences = preferences => {
@@ -68,7 +69,9 @@ export const savePreferences = async preferences => {
     throw new Error("Could not parse CID");
   }
   try {
-    await fission.pin(cid);
+    if (username && password && ipfsProvider) {
+      await pin(cid, { username, password }, ipfsProvider);
+    }
   } catch (err) {
     console.error(err);
   }


### PR DESCRIPTION
# Problem
env variables are required and the app will error if not included properly

# Solution
- Make heroku variables option. If not included, then CIDs will not be pinned.
- Make bootstrap node optional. If not included, then in browser-node will only bootstrap to defaults