### PR TITLE
update get-ipfs and provide specific peers for browser vs local nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ A front end application to demonstrate portable user settings through IPFS. Chan
 ## Environment
 ```
 REACT_APP_DEFAULT_CID = QmUWWqCNSdZmus7mc52um5cpqUi1CaE97AzBTY7iWfBXV9
-REACT_APP_BOOTSTRAP_NODE = /dns4/ipfs.runfission.com/tcp/4003/wss/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw
+REACT_APP_BOOTSTRAP_NODE_TCP = /ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw
+REACT_APP_BOOTSTRAP_NODE_WSS = /dns4/ipfs.runfission.com/tcp/4003/wss/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw
 REACT_APP_INTERPLANETARY_FISSION_URL = https://runfission.com
 REACT_APP_INTERPLANETARY_FISSION_USERNAME = ADD_USERNAME_HERE
 REACT_APP_INTERPLANETARY_FISSION_PASSWORD = ADD_PASSWORD_HERE
@@ -29,9 +30,9 @@ REACT_APP_INTERPLANETARY_FISSION_PASSWORD = ADD_PASSWORD_HERE
 
 `REACT_APP_DEFAULT_CID`: the cid that contains the default settings that you want a new user to see. You can set it to the above value for our recommended defaults (or leave it blank and it will default to that).
 
-`REACT_APP_BOOTSTRAP_NODE`: the multiaddr of the ipfs node that you would like the user's node to connect to. You can set it to the above value to connect to the IPFS node that Fission hosts (or leave it blank and it will default to that). 
+`REACT_APP_BOOTSTRAP_NODE_TCP`: the multiaddr of the ipfs node that you would like the user's node to connect to through tcp (for instance with a local daemon through ipfs companion). You can set it to the above value to connect to the IPFS node that Fission hosts (or leave it blank and it will default to that). 
 
-**Note:** if you use a custom node, it must be interoperable with `js-ipfs`. This means that it either needs to connect via WebRTC or Secured Websockets (notice the `wss` in the above multiaddr).
+`REACT_APP_BOOTSTRAP_NODE_WSS`: the multiaddr of the ipfs node that you would like the user's node to connect to through wss (if the user does not have an ipfs-enabled browser and falls back to an in-browser js-ipfs daemon). You can set it to the above value to connect to the IPFS node that Fission hosts (or leave it blank and it will default to that). **Note:** if you use a custom node, it must be interoperable with `js-ipfs`. This means that it either needs to connect via WebRTC or Secured Websockets (notice the `wss` in the above multiaddr).
 
 `REACT_APP_INTERPLANETARY_FISSION_...`: the last three variables are your provisioned account information for using the Fission web-api. These are used for pinning content to the Fission IPFS node so that content will stay online even after a user goes offline. If you leave them blank, the webapp will not pin user content. At the moment, these can be obtained by joining the [Fission Heroku add-on alpha](https://elements.heroku.com/addons/interplanetary-fission).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5907,9 +5907,9 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-ipfs": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/get-ipfs/-/get-ipfs-0.0.3.tgz",
-      "integrity": "sha512-YxDHnEzXRCdyg5UcMw+cUSfZu4ex/QgP9PsBVt5Mk39hRv0VwHtIzHZpu6DMkH8r+LKKcaxk8Lex5qzVFEbYrg=="
+      "version": "1.0.0-rc",
+      "resolved": "https://registry.npmjs.org/get-ipfs/-/get-ipfs-1.0.0-rc.tgz",
+      "integrity": "sha512-lu6tA2MEttxA6fab7Sti+vaQuq7hI19Og1f8/ujZgjlNJdXPqemsh+p9vgt46oxZF8JAgNJj2B6WOskwp2uXvw=="
     },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@material-ui/icons": "^4.2.1",
     "classnames": "^2.2.6",
     "eslint-utils": "1.4.2",
-    "get-ipfs": "^0.0.3",
+    "get-ipfs": "^1.0.0-rc",
     "gh-pages": "^2.1.1",
     "prop-types": "^15.7.2",
     "react": "^16.9.0",

--- a/src/ipfs/preferences.js
+++ b/src/ipfs/preferences.js
@@ -5,9 +5,13 @@ const ipfsProvider =
   process.env.REACT_APP_INTERPLANETARY_FISSION_URL || "https://hostless.dev";
 const username = process.env.REACT_APP_INTERPLANETARY_FISSION_USERNAME;
 const password = process.env.REACT_APP_INTERPLANETARY_FISSION_PASSWORD;
-const bootstrapNode =
-  process.env.REACT_APP_BOOTSTRAP_NODE ||
+const bootstrapNodeWSS =
+  process.env.REACT_APP_BOOTSTRAP_NODE_WSS ||
   "/dns4/ipfs.runfission.com/tcp/4003/wss/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw";
+const bootstrapNodeTCP =
+  process.env.REACT_APP_BOOTSTRAP_NODE_TCP ||
+  "/ip4/3.215.160.238/tcp/4001/ipfs/QmVLEz2SxoNiFnuyLpbXsH6SvjPTrHNMU88vCQZyhgBzgw";
+
 
 export const DefaultCid =
   process.env.REACT_APP_DEFAULT_CID ||
@@ -15,7 +19,8 @@ export const DefaultCid =
 
 const getIpfs = async () => {
   return getIpfsWithConfig({
-    bootstrap: [bootstrapNode]
+    localPeers: [bootstrapNodeTCP],
+    browserPeers: [bootstrapNodeWSS]
   });
 };
 


### PR DESCRIPTION
# Problem
Same multiaddr is being provided to the ipfs node regardless of if it is local or running in-browser

# Solution
Update `get-ipfs` and provide separate multiaddrs for browser vs local nodes